### PR TITLE
Improvements to org-variable-pitch

### DIFF
--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -88,16 +88,18 @@ This face is used to keep them in monospace when using
        ,code))))
 
 (defvar org-variable-pitch-fixed-faces
-  '(org-table
-    org-code
-    org-special-keyword
-    org-verbatim
-    org-meta-line
-    org-block
+  '(org-block
     org-block-begin-line
     org-block-end-line
+    org-code
+    org-document-info-keyword
     org-done
-    org-document-info-keyword)
+    org-formula
+    org-meta-line
+    org-special-keyword
+    org-table
+    org-todo
+    org-verbatim)
   "Faces to keep fixed-width when using ‘org-variable-pitch-minor-mode’.")
 
 ;;;###autoload
@@ -108,7 +110,6 @@ Keeps some elements in fixed pitch in order to keep layout."
   (variable-pitch-mode
    (if org-variable-pitch-minor-mode 1 0))
   (set-face-attribute 'org-variable-pitch-face nil :font org-variable-pitch-fixed-font)
-  (set-face-attribute 'org-todo nil :font org-variable-pitch-fixed-font)
   (dolist (face org-variable-pitch-fixed-faces)
     (if (facep face)
         (set-face-attribute face nil :font org-variable-pitch-fixed-font)

--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -100,6 +100,7 @@ This face is used to keep them in monospace when using
     org-document-info-keyword)
   "Faces to keep fixed-width when using ‘org-variable-pitch-minor-mode’.")
 
+;;;###autoload
 (define-minor-mode org-variable-pitch-minor-mode
   "Set up the buffer to be partially in variable pitch.
 Keeps some elements in fixed pitch in order to keep layout."

--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -102,20 +102,29 @@ This face is used to keep them in monospace when using
     org-verbatim)
   "Faces to keep fixed-width when using ‘org-variable-pitch-minor-mode’.")
 
+(defvar org-variable-pitch--cookies nil
+  "Face remappings to restore when the minor mode is deactivated")
+
 ;;;###autoload
 (define-minor-mode org-variable-pitch-minor-mode
   "Set up the buffer to be partially in variable pitch.
 Keeps some elements in fixed pitch in order to keep layout."
   nil " OVP" nil
-  (variable-pitch-mode
-   (if org-variable-pitch-minor-mode 1 0))
   (set-face-attribute 'org-variable-pitch-face nil :font org-variable-pitch-fixed-font)
-  (dolist (face org-variable-pitch-fixed-faces)
-    (if (facep face)
-        (set-face-attribute face nil :font org-variable-pitch-fixed-font)
-      (message "‘%s’ is not a valid face, thus OVP skipped it"
-               (symbol-name face))))
-  (font-lock-add-keywords nil org-variable-pitch-font-lock-keywords)
+  (if org-variable-pitch-minor-mode
+      (progn
+        (variable-pitch-mode 1)
+        (dolist (face org-variable-pitch-fixed-faces)
+          (if (facep face)
+              (push (face-remap-add-relative face 'org-variable-pitch-face)
+                    org-variable-pitch--cookies)
+            (message "‘%s’ is not a valid face, thus OVP skipped it"
+                     (symbol-name face))))
+        (font-lock-add-keywords nil org-variable-pitch-font-lock-keywords))
+    (variable-pitch-mode -1)
+    (mapc #'face-remap-remove-relative org-variable-pitch--cookies)
+    (setq org-variable-pitch--cookies nil)
+    (font-lock-remove-keywords nil org-variable-pitch-font-lock-keywords))
   (font-lock-ensure))
 
 


### PR DESCRIPTION
- Use buffer-local `face-remapping-alist` instead of overriding face attributes globally
- remove font-lock keywords when deactivated
- Add `org-formula` to default list of fixed faces, to keep table cells with verbatim text properly aligned 
- Add autoload so the `(require 'org)` doesn't get called on startup