### PR TITLE
org-variable-pitch: Only set font-family for face to support text scaling

### DIFF
--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -110,7 +110,7 @@ This face is used to keep them in monospace when using
   "Set up the buffer to be partially in variable pitch.
 Keeps some elements in fixed pitch in order to keep layout."
   nil " OVP" nil
-  (set-face-attribute 'org-variable-pitch-face nil :font org-variable-pitch-fixed-font)
+  (set-face-attribute 'org-variable-pitch-face nil :family org-variable-pitch-fixed-font)
   (if org-variable-pitch-minor-mode
       (progn
         (variable-pitch-mode 1)


### PR DESCRIPTION
If you set `:font` it will set all of the following:
- `:family`
- `:foundry`
- `:width`
- `:height`
- `:weight`
- `:slant`

When `:height` is set you loose the ability to be able to scale the face
with `text-scale-increase`/`text-scale-decrease`. By only setting the
`:family` we avoid this.