### PR TITLE
org-date face needs to be in fixed font

### DIFF
--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -99,7 +99,8 @@ This face is used to keep them in monospace when using
     org-special-keyword
     org-table
     org-todo
-    org-verbatim)
+    org-verbatim
+    org-date)
   "Faces to keep fixed-width when using ‘org-variable-pitch-minor-mode’.")
 
 (defvar org-variable-pitch--cookies nil


### PR DESCRIPTION
The face org-date is often in tables and messes up table alignments.

P.S. I'd love to see org-variable-pitch as an independent package in MELPA