### PR TITLE
Add org-indent to fixed-pitch faces

### DIFF
--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -96,6 +96,7 @@ This face is used to keep them in monospace when using
     org-document-info-keyword
     org-done
     org-formula
+    org-indent
     org-meta-line
     org-special-keyword
     org-table


### PR DESCRIPTION
if using `org-indent-mode` the face `org-indent` needs to be fixed-pitch, otherwise the indentation can get off when displaying code blocks. See the note at the bottom of [this](https://zzamboni.org/post/beautifying-org-mode-in-emacs/#step-2-setting-up-variable-pitch-and-fixed-pitch-faces) article. 