### PR TITLE
Align headings in org-variable-pitch

### DIFF
--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -85,6 +85,16 @@
   :group 'org-variable-pitch
   :type '(repeat symbol))
 
+(defcustom org-variable-pitch-fontify-headline-prefix nil
+  "Fontify the headline prefix.
+When non-nil, headline prefix will use the monospace face.
+Otherwise the headline will use the default `org-level-*' face.
+
+Note that this will drop all `org-level-*' face styles and only
+apply the monospace face to the headline prefix."
+  :group 'org-variable-pitch
+  :type 'boolean)
+
 (defface org-variable-pitch-face
   `((t . (:family ,org-variable-pitch-fixed-font)))
   "Face for initial space and list item bullets.
@@ -92,19 +102,24 @@ This face is used to keep them in monospace when using
 ‘org-variable-pitch-minor-mode’."
   :group 'org-variable-pitch)
 
-(defvar org-variable-pitch-font-lock-keywords
-  (let ((code '(0 (put-text-property
+(defvar org-variable-pitch-font-lock-keywords)
+(defvar org-variable-pitch-headline-font-lock-keywords)
+(let ((code '(0 (put-text-property
                    (match-beginning 0)
                    (match-end 0)
                    'face 'org-variable-pitch-face))))
+  (setq
+   org-variable-pitch-font-lock-keywords
     `((,(rx bol (1+ blank))
        ,code)
       (,(rx bol (0+ blank)
             (or (: (or (+ digit) letter) (in ".)"))
-                (: (in "-+")
-                   (opt blank "[" (in "-X ") "]"))
-                (: (1+ blank) "\*"))
+                (: (or (in "-+") (1+ blank "\*"))
+                   (opt blank "[" (in "-X ") "]")))
             blank)
+       ,code))
+    org-variable-pitch-headline-font-lock-keywords
+    `((,(rx bol (1+ "\*") blank)
        ,code))))
 
 
@@ -126,11 +141,14 @@ Keeps some elements in fixed pitch in order to keep layout."
                     org-variable-pitch--cookies)
             (message "‘%s’ is not a valid face, thus OVP skipped it"
                      (symbol-name face))))
-        (font-lock-add-keywords nil org-variable-pitch-font-lock-keywords))
+        (font-lock-add-keywords nil org-variable-pitch-font-lock-keywords)
+        (when org-variable-pitch-fontify-headline-prefix
+          (font-lock-add-keywords nil org-variable-pitch-headline-font-lock-keywords)))
     (variable-pitch-mode -1)
     (mapc #'face-remap-remove-relative org-variable-pitch--cookies)
     (setq org-variable-pitch--cookies nil)
-    (font-lock-remove-keywords nil org-variable-pitch-font-lock-keywords))
+    (font-lock-remove-keywords nil org-variable-pitch-font-lock-keywords)
+    (font-lock-remove-keywords nil org-variable-pitch-headline-font-lock-keywords))
   (font-lock-ensure))
 
 


### PR DESCRIPTION
I noticed that when I am scaling org-level faces that the headings won't be aligned with the section. One way to solve this is to also apply the face to the heading prefix `* `, `** ` etc.

I also noticed that when using `*` for lists and having checkboxes, the style for checkboxes won't be applied, so I also moved these in together with the other list prefixes to make it apply.

Is there any case where you wouldn't want to align the headings?

See this for the before and after, with the regex hi-lighted to indicate where the face applies and not:

Before:
![variable-pitch-before](https://user-images.githubusercontent.com/280235/69435169-54800c00-0d3f-11ea-8a49-717aa7219d9b.png)

After:
![variable-pitch-after](https://user-images.githubusercontent.com/280235/69435191-5d70dd80-0d3f-11ea-808f-f864f974a901.png)

PS.
Commit message was a bit long when I included `org-variable-pitch-font-lock-keywords`, should I skip it, or are you okay with the message overflowing?