### PR TITLE
paper-theme.el: use magenta for preprocessor-face

### DIFF
--- a/paper-theme.el
+++ b/paper-theme.el
@@ -330,6 +330,7 @@ May be used to refresh after tweaking some variables."
        (quote (font-lock-keyword-face        ,paper-magenta-on-paper-face))
        (quote (font-lock-type-face           ,paper-magenta-on-paper-face))
        (quote (font-lock-constant-face       ,paper-magenta-on-paper-face))
+       (quote (font-lock-preprocessor-face   ,paper-magenta-on-paper-face))
 
        ;; === Org titles ===
        ,(when paper-use-varying-heights-for-org-title-headlines


### PR DESCRIPTION
This is of course a matter of taste, but I prefer more visual distinction for preprocessor commands.